### PR TITLE
Clean up npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.npmignore
+.gitignore
+.travis.yml
+.editorconfig
+test/
+build.js


### PR DESCRIPTION
This package is very useful and its content is very small.

Unfortunately, npm package contains many development files. This development files even bigger than actual useful package content :D. Let’s remove them to make `node_module` smaller.

Also, these files raise warnings on out build CI server:

```
warning: CRLF will be replaced by LF in node_modules/void-elements/.gitattributes.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/void-elements/.npmignore.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/void-elements/.travis.yml.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/void-elements/LICENSE.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/void-elements/README.md.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/void-elements/pre-publish.js.
The file will have its original line endings in your working directory.
warning: CRLF will be replaced by LF in node_modules/void-elements/test/index.js.
The file will have its original line endings in your working directory.
```

@ForbesLindesay @TimothyGu 